### PR TITLE
Refactor command validators and update DTO usage

### DIFF
--- a/src/SAX.Application/Features/Content/Commands/BlogPost/CreateBlogPost/CreateBlogPostCommandValidator.cs
+++ b/src/SAX.Application/Features/Content/Commands/BlogPost/CreateBlogPost/CreateBlogPostCommandValidator.cs
@@ -9,6 +9,6 @@ public class CreateBlogPostCommandValidator : AbstractValidator<CreateBlogPostCo
     public CreateBlogPostCommandValidator()
     {
         RuleFor(x => x.CreateBlogPostDto).NotNull().WithMessage("CreateBlogPostDto cannot be null.");
-        RuleFor(x => x.CreateBlogPostDto).SetValidator(new CreateBlogPostDtoValidator());
+        RuleFor(x => x.CreateBlogPostDto!).SetValidator(new CreateBlogPostDtoValidator());
     }
 }

--- a/src/SAX.Application/Features/Content/Commands/BlogPost/UpdateBlogPost/UpdateBlogPostCommandValidator.cs
+++ b/src/SAX.Application/Features/Content/Commands/BlogPost/UpdateBlogPost/UpdateBlogPostCommandValidator.cs
@@ -9,6 +9,6 @@ public class UpdateBlogPostCommandValidator : AbstractValidator<UpdateBlogPostCo
     public UpdateBlogPostCommandValidator()
     {
         RuleFor(p => p.UpdateBlogPostDto).NotNull().WithMessage("UpdateBlogPostDto cannot be null.");
-        RuleFor(x => x.UpdateBlogPostDto).SetValidator(new UpdateBlogPostDtoValidator());
+        RuleFor(x => x.UpdateBlogPostDto!).SetValidator(new UpdateBlogPostDtoValidator());
     }
 }

--- a/src/SAX.Application/Features/Content/Commands/Category/CreateCategory/CreateCategoryCommandValidator.cs
+++ b/src/SAX.Application/Features/Content/Commands/Category/CreateCategory/CreateCategoryCommandValidator.cs
@@ -9,6 +9,6 @@ public class CreateCategoryCommandValidator : AbstractValidator<CreateCategoryCo
     public CreateCategoryCommandValidator()
     {
         RuleFor(x => x.CreateCategoryDto).NotNull().WithMessage("CreateCategoryDto cannot be null.");
-        RuleFor(x => x.CreateCategoryDto).SetValidator(new CreateCategoryDtoValidator());
+        RuleFor(x => x.CreateCategoryDto!).SetValidator(new CreateCategoryDtoValidator());
     }
 }

--- a/src/SAX.Application/Features/Content/Commands/Category/DeleteCategory/DeleteCategoryCommand.cs
+++ b/src/SAX.Application/Features/Content/Commands/Category/DeleteCategory/DeleteCategoryCommand.cs
@@ -1,5 +1,10 @@
-﻿namespace SAX.Application.Features.Content.Commands.Category.DeleteCategory;
+﻿using FluentResults;
 
-public class DeleteCategoryCommand
+using MediatR;
+
+namespace SAX.Application.Features.Content.Commands.Category.DeleteCategory;
+
+public record DeleteCategoryCommand : IRequest<Result>
 {
+    public Guid Id { get; set; }
 }

--- a/src/SAX.Application/Features/Content/Commands/Category/DeleteCategory/DeleteCategoryCommandHandler.cs
+++ b/src/SAX.Application/Features/Content/Commands/Category/DeleteCategory/DeleteCategoryCommandHandler.cs
@@ -1,5 +1,32 @@
-﻿namespace SAX.Application.Features.Content.Commands.Category.DeleteCategory;
+﻿using FluentResults;
 
-public class DeleteCategoryCommandHandler
+using MediatR;
+
+using SAX.Application.Common.Contracts.Persistence.Repositories.Content;
+using SAX.Application.Common.Exceptions;
+
+namespace SAX.Application.Features.Content.Commands.Category.DeleteCategory;
+
+public class DeleteCategoryCommandHandler : IRequestHandler<DeleteCategoryCommand, Result>
 {
+    private readonly ICategoryRepository _categoryRepository;
+
+    public DeleteCategoryCommandHandler(ICategoryRepository categoryRepository)
+    {
+        _categoryRepository = categoryRepository;
+    }
+
+    public async Task<Result> Handle(DeleteCategoryCommand request, CancellationToken cancellationToken)
+    {
+        var categoryToDelete = await _categoryRepository.GetByIdAsync(request.Id, cancellationToken);
+
+        if (categoryToDelete == null)
+        {
+            return Result.Fail(new SobActXNotFoundException($"Category with Id {request.Id} not found.").Message);
+        }
+
+        await _categoryRepository.DeleteAsync(categoryToDelete, cancellationToken);
+
+        return Result.Ok();
+    }
 }

--- a/src/SAX.Application/Features/Content/Commands/Category/UpdateCategory/UpdateCategoryCommandValidator.cs
+++ b/src/SAX.Application/Features/Content/Commands/Category/UpdateCategory/UpdateCategoryCommandValidator.cs
@@ -9,6 +9,6 @@ public class UpdateCategoryCommandValidator : AbstractValidator<UpdateCategoryCo
     public UpdateCategoryCommandValidator()
     {
         RuleFor(x => x.UpdateCategoryDto).NotNull().WithMessage("UpdateCategoryDto cannot be null.");
-        RuleFor(x => x.UpdateCategoryDto).SetValidator(new UpdateCategoryDtoValidator());
+        RuleFor(x => x.UpdateCategoryDto!).SetValidator(new UpdateCategoryDtoValidator());
     }
 }

--- a/src/SAX.Application/Features/Content/Commands/Media/CreateMedia/CreateMediaCommandValidator.cs
+++ b/src/SAX.Application/Features/Content/Commands/Media/CreateMedia/CreateMediaCommandValidator.cs
@@ -9,6 +9,6 @@ public class CreateMediaCommandValidator : AbstractValidator<CreateMediaCommand>
     public CreateMediaCommandValidator()
     {
         RuleFor(x => x.CreateMediaDto).NotNull().WithMessage("CreateMediaDto cannot be null.");
-        RuleFor(x => x.CreateMediaDto).SetValidator(new CreateMediaDtoValidator());
+        RuleFor(x => x.CreateMediaDto!).SetValidator(new CreateMediaDtoValidator());
     }
 }

--- a/src/SAX.Application/Features/Content/Commands/Media/UpdateMedia/UpdateMediaCommandValidator.cs
+++ b/src/SAX.Application/Features/Content/Commands/Media/UpdateMedia/UpdateMediaCommandValidator.cs
@@ -9,6 +9,6 @@ public class UpdateMediaCommandValidator : AbstractValidator<UpdateMediaCommand>
     public UpdateMediaCommandValidator()
     {
         RuleFor(x => x.UpdateMediaDto).NotNull().WithMessage("UpdateMediaDto cannot be null.");
-        RuleFor(x => x.UpdateMediaDto).SetValidator(new UpdateMediaDtoValidator());
+        RuleFor(x => x.UpdateMediaDto!).SetValidator(new UpdateMediaDtoValidator());
     }
 }

--- a/src/SAX.Application/Features/Content/Commands/Page/CreatePage/CreatePageCommandValidator.cs
+++ b/src/SAX.Application/Features/Content/Commands/Page/CreatePage/CreatePageCommandValidator.cs
@@ -9,6 +9,6 @@ public class CreatePageCommandValidator : AbstractValidator<CreatePageCommand>
     public CreatePageCommandValidator()
     {
         RuleFor(x => x.CreatePageDto).NotNull().WithMessage("CreatePageDto cannot be null.");
-        RuleFor(x => x.CreatePageDto).SetValidator(new CreatePageDtoValidator());
+        RuleFor(x => x.CreatePageDto!).SetValidator(new CreatePageDtoValidator());
     }
 }

--- a/src/SAX.Application/Features/Content/Commands/Page/UpdatePage/UpdatePageCommandValidator.cs
+++ b/src/SAX.Application/Features/Content/Commands/Page/UpdatePage/UpdatePageCommandValidator.cs
@@ -9,6 +9,6 @@ public class UpdatePageCommandValidator : AbstractValidator<UpdatePageCommand>
     public UpdatePageCommandValidator()
     {
         RuleFor(x => x.UpdatePageDto).NotNull().WithMessage("UpdatePageDto cannot be null.");
-        RuleFor(x => x.UpdatePageDto).SetValidator(new UpdatePageDtoValidator());
+        RuleFor(x => x.UpdatePageDto!).SetValidator(new UpdatePageDtoValidator());
     }
 }

--- a/src/SAX.Application/Features/Content/Commands/Tag/CreateTag/CreateTagCommandValidator.cs
+++ b/src/SAX.Application/Features/Content/Commands/Tag/CreateTag/CreateTagCommandValidator.cs
@@ -9,6 +9,6 @@ public class CreateTagCommandValidator : AbstractValidator<CreateTagCommand>
     public CreateTagCommandValidator()
     {
         RuleFor(x => x.CreateTagDto).NotNull().WithMessage("CreateTagDto cannot be null.");
-        RuleFor(x => x.CreateTagDto).SetValidator(new CreateTagDtoValidator());
+        RuleFor(x => x.CreateTagDto!).SetValidator(new CreateTagDtoValidator());
     }
 }

--- a/src/SAX.Application/Features/Content/Commands/Tag/UpdateTag/UpdateTagCommandValidator.cs
+++ b/src/SAX.Application/Features/Content/Commands/Tag/UpdateTag/UpdateTagCommandValidator.cs
@@ -9,6 +9,6 @@ public class UpdateTagCommandValidator : AbstractValidator<UpdateTagCommand>
     public UpdateTagCommandValidator()
     {
         RuleFor(x => x.UpdateTagDto).NotNull().WithMessage("UpdateTagDto cannot be null.");
-        RuleFor(x => x.UpdateTagDto).SetValidator(new UpdateTagDtoValidator());
+        RuleFor(x => x.UpdateTagDto!).SetValidator(new UpdateTagDtoValidator());
     }
 }

--- a/src/SAX.Application/Features/Customers/Commands/Customer/CreateCustomer/CreateCustomerCommandValidator.cs
+++ b/src/SAX.Application/Features/Customers/Commands/Customer/CreateCustomer/CreateCustomerCommandValidator.cs
@@ -9,6 +9,6 @@ public class CreateCustomerCommandValidator : AbstractValidator<CreateCustomerCo
     public CreateCustomerCommandValidator()
     {
         RuleFor(x => x.CreateCustomerDto).NotNull().WithMessage("CreateCustomerDto is required");
-        RuleFor(x => x.CreateCustomerDto).SetValidator(new CreateCustomerDtoValidator());
+        RuleFor(x => x.CreateCustomerDto!).SetValidator(new CreateCustomerDtoValidator());
     }
 }

--- a/src/SAX.Application/Features/Customers/Commands/Customer/UpdateCustomer/UpdateCustomerCommandValidator.cs
+++ b/src/SAX.Application/Features/Customers/Commands/Customer/UpdateCustomer/UpdateCustomerCommandValidator.cs
@@ -9,6 +9,6 @@ public class UpdateCustomerCommandValidator : AbstractValidator<UpdateCustomerCo
     public UpdateCustomerCommandValidator()
     {
         RuleFor(x => x.UpdateCustomerDto).NotNull().WithMessage("UpdateCustomerDto is required");
-        RuleFor(x => x.UpdateCustomerDto).SetValidator(new UpdateCustomerDtoValidator());
+        RuleFor(x => x.UpdateCustomerDto!).SetValidator(new UpdateCustomerDtoValidator());
     }
 }

--- a/src/SAX.Application/Features/Inventory/Commands/ProductInventory/CreateProductInventory/CreateProductInventoryCommand.cs
+++ b/src/SAX.Application/Features/Inventory/Commands/ProductInventory/CreateProductInventory/CreateProductInventoryCommand.cs
@@ -2,11 +2,11 @@
 
 using MediatR;
 
-using SAX.Application.Features.Products.DTOs.Product;
+using SAX.Application.Features.Inventory.DTOs.ProductInventory;
 
 namespace SAX.Application.Features.Inventory.Commands.ProductInventory.CreateProductInventory;
 
 public record CreateProductInventoryCommand : IRequest<Result<Guid>>
 {
-    public CreateProductDto? CreateProductDto { get; set; }
+    public CreateProductInventoryDto? CreateProductInventoryDto { get; set; }
 }

--- a/src/SAX.Application/Features/Inventory/Commands/ProductInventory/CreateProductInventory/CreateProductInventoryCommandHandler.cs
+++ b/src/SAX.Application/Features/Inventory/Commands/ProductInventory/CreateProductInventory/CreateProductInventoryCommandHandler.cs
@@ -33,7 +33,7 @@ public class CreateProductInventoryCommandHandler : IRequestHandler<CreateProduc
             return Result.Fail<Guid>(new SobActXValidationException(validationResult.Errors).Message).WithErrors(errors);
         }
 
-        var productInventoryDto = request.CreateProductDto;
+        var productInventoryDto = request.CreateProductInventoryDto;
         var productInventoryToCreate = _mapper.Map<Domain.Entities.Inventory.ProductInventory>(productInventoryDto);
         var createdProductInventory = await _productInventoryRepository.CreateAsync(productInventoryToCreate, cancellationToken);
 

--- a/src/SAX.Application/Features/Inventory/Commands/ProductInventory/CreateProductInventory/CreateProductInventoryCommandValidator.cs
+++ b/src/SAX.Application/Features/Inventory/Commands/ProductInventory/CreateProductInventory/CreateProductInventoryCommandValidator.cs
@@ -1,6 +1,6 @@
 ﻿using FluentValidation;
 
-using SAX.Application.Features.Products.Validators;
+using SAX.Application.Features.Inventory.Validators;
 
 namespace SAX.Application.Features.Inventory.Commands.ProductInventory.CreateProductInventory;
 
@@ -8,7 +8,7 @@ public class CreateProductInventoryCommandValidator : AbstractValidator<CreatePr
 {
     public CreateProductInventoryCommandValidator()
     {
-        RuleFor(x => x.CreateProductDto).NotNull().WithMessage("CreateProductDto is required");
-        RuleFor(x => x.CreateProductDto).SetValidator(new CreateProductDtoValidator());
+        RuleFor(x => x.CreateProductInventoryDto).NotNull().WithMessage("CreateProductInventoryDto is required");
+        RuleFor(x => x.CreateProductInventoryDto!).SetValidator(new CreateProductInventoryDtoValidator());
     }
 }

--- a/src/SAX.Application/Features/Inventory/Commands/ProductInventory/UpdateProductInventory/UpdateProductInventoryCommand.cs
+++ b/src/SAX.Application/Features/Inventory/Commands/ProductInventory/UpdateProductInventory/UpdateProductInventoryCommand.cs
@@ -1,5 +1,12 @@
-﻿namespace SAX.Application.Features.Inventory.Commands.ProductInventory.UpdateProductInventory;
+﻿using FluentResults;
 
-public class UpdateProductInventoryCommand
+using MediatR;
+
+using SAX.Application.Features.Inventory.DTOs.ProductInventory;
+
+namespace SAX.Application.Features.Inventory.Commands.ProductInventory.UpdateProductInventory;
+
+public record UpdateProductInventoryCommand : IRequest<Result>
 {
+    public UpdateProductInventoryDto? UpdateProductInventoryDto { get; set; }
 }

--- a/src/SAX.Application/Features/Inventory/Commands/ProductInventory/UpdateProductInventory/UpdateProductInventoryCommandHandler.cs
+++ b/src/SAX.Application/Features/Inventory/Commands/ProductInventory/UpdateProductInventory/UpdateProductInventoryCommandHandler.cs
@@ -1,5 +1,52 @@
-﻿namespace SAX.Application.Features.Inventory.Commands.ProductInventory.UpdateProductInventory;
+﻿using AutoMapper;
 
-public class UpdateProductInventoryCommandHandler
+using FluentResults;
+
+using FluentValidation;
+
+using MediatR;
+
+using SAX.Application.Common.Contracts.Persistence.Repositories.Inventory;
+using SAX.Application.Common.Exceptions;
+
+namespace SAX.Application.Features.Inventory.Commands.ProductInventory.UpdateProductInventory;
+
+public class UpdateProductInventoryCommandHandler : IRequestHandler<UpdateProductInventoryCommand, Result>
 {
+    private readonly IMapper _mapper;
+    private readonly IProductInventoryRepository _productInventoryRepository;
+    private readonly IValidator<UpdateProductInventoryCommand> _validator;
+
+    public UpdateProductInventoryCommandHandler(IMapper mapper, IProductInventoryRepository productInventoryRepository, IValidator<UpdateProductInventoryCommand> validator)
+    {
+        _mapper = mapper;
+        _productInventoryRepository = productInventoryRepository;
+        _validator = validator;
+    }
+
+    public async Task<Result> Handle(UpdateProductInventoryCommand request, CancellationToken cancellationToken)
+    {
+        var validationResult = await _validator.ValidateAsync(request, cancellationToken);
+        if (!validationResult.IsValid)
+        {
+            var errors = validationResult.Errors.Select(e => e.ErrorMessage).ToList();
+            return Result.Fail(new SobActXValidationException(validationResult.Errors).Message).WithErrors(errors);
+        }
+
+        var productInventoryDto = request.UpdateProductInventoryDto;
+        if (productInventoryDto == null)
+        {
+            return Result.Fail("Product Inventory is null.");
+        }
+        var productInventoryToUpdate = await _productInventoryRepository.GetByIdAsync(productInventoryDto.ProductInventoryId, cancellationToken);
+        if (productInventoryToUpdate == null)
+        {
+            return Result.Fail($"Product Inventory with id: {productInventoryDto.ProductInventoryId} not found.");
+        }
+
+        _mapper.Map(productInventoryDto, productInventoryToUpdate);
+        await _productInventoryRepository.UpdateAsync(productInventoryToUpdate, cancellationToken);
+
+        return Result.Ok();
+    }
 }

--- a/src/SAX.Application/Features/Inventory/Commands/ProductInventory/UpdateProductInventory/UpdateProductInventoryCommandValidator.cs
+++ b/src/SAX.Application/Features/Inventory/Commands/ProductInventory/UpdateProductInventory/UpdateProductInventoryCommandValidator.cs
@@ -1,5 +1,14 @@
-﻿namespace SAX.Application.Features.Inventory.Commands.ProductInventory.UpdateProductInventory;
+﻿using FluentValidation;
 
-public class UpdateProductInventoryCommandValidator
+using SAX.Application.Features.Inventory.Validators;
+
+namespace SAX.Application.Features.Inventory.Commands.ProductInventory.UpdateProductInventory;
+
+public class UpdateProductInventoryCommandValidator : AbstractValidator<UpdateProductInventoryCommand>
 {
+    public UpdateProductInventoryCommandValidator()
+    {
+        RuleFor(p => p.UpdateProductInventoryDto).NotNull().WithMessage("{PropertyName} cannot be null.");
+        RuleFor(p => p.UpdateProductInventoryDto!).SetValidator(new UpdateProductInventoryDtoValidator());
+    }
 }

--- a/src/SAX.Application/Features/Inventory/Commands/StockMovement/CreateStockMovement/CreateStockMovementCommand.cs
+++ b/src/SAX.Application/Features/Inventory/Commands/StockMovement/CreateStockMovement/CreateStockMovementCommand.cs
@@ -8,5 +8,5 @@ namespace SAX.Application.Features.Inventory.Commands.StockMovement.CreateStockM
 
 public record CreateStockMovementCommand : IRequest<Result<Guid>>
 {
-    public StockMovementDto? StockMovement { get; set; }
+    public StockMovementDto? StockMovementDto { get; set; }
 }

--- a/src/SAX.Application/Features/Inventory/Commands/StockMovement/CreateStockMovement/CreateStockMovementCommandHandler.cs
+++ b/src/SAX.Application/Features/Inventory/Commands/StockMovement/CreateStockMovement/CreateStockMovementCommandHandler.cs
@@ -33,7 +33,7 @@ public class CreateStockMovementCommandHandler : IRequestHandler<CreateStockMove
             return Result.Fail<Guid>(new SobActXValidationException(validationResult.Errors).Message).WithErrors(errors);
         }
 
-        var stockMovementDto = request.StockMovement;
+        var stockMovementDto = request.StockMovementDto;
         var stockMovementToCreate = _mapper.Map<Domain.Entities.Inventory.StockMovement>(stockMovementDto);
         var createdStockMovement = await _stockMovementRepository.CreateAsync(stockMovementToCreate, cancellationToken);
 

--- a/src/SAX.Application/Features/Inventory/Commands/StockMovement/CreateStockMovement/CreateStockMovementCommandValidator.cs
+++ b/src/SAX.Application/Features/Inventory/Commands/StockMovement/CreateStockMovement/CreateStockMovementCommandValidator.cs
@@ -8,8 +8,7 @@ public class CreateStockMovementCommandValidator : AbstractValidator<CreateStock
 {
     public CreateStockMovementCommandValidator()
     {
-        RuleFor(p => p.StockMovement)
-            .NotNull().WithMessage("{PropertyName} cannot be null.")
-            .SetValidator(new StockMovementDtoValidator());
+        RuleFor(p => p.StockMovementDto).NotNull().WithMessage("{PropertyName} cannot be null.");
+        RuleFor(p => p.StockMovementDto!).SetValidator(new StockMovementDtoValidator());
     }
 }

--- a/src/SAX.Application/Features/Inventory/Commands/Warehouse/CreateWarehouse/CreateWarehouseCommandValidator.cs
+++ b/src/SAX.Application/Features/Inventory/Commands/Warehouse/CreateWarehouse/CreateWarehouseCommandValidator.cs
@@ -9,6 +9,6 @@ public class CreateWarehouseCommandValidator : AbstractValidator<CreateWarehouse
     public CreateWarehouseCommandValidator()
     {
         RuleFor(x => x.CreateWarehouseDto).NotNull().WithMessage("{PropertyName} is required.");
-        RuleFor(x => x.CreateWarehouseDto).SetValidator(new CreateWarehouseDtoValidator());
+        RuleFor(x => x.CreateWarehouseDto!).SetValidator(new CreateWarehouseDtoValidator());
     }
 }

--- a/src/SAX.Application/Features/Inventory/Commands/Warehouse/UpdateWarehouse/UpdateWarehouseCommandValidator.cs
+++ b/src/SAX.Application/Features/Inventory/Commands/Warehouse/UpdateWarehouse/UpdateWarehouseCommandValidator.cs
@@ -8,8 +8,7 @@ public class UpdateWarehouseCommandValidator : AbstractValidator<UpdateWarehouse
 {
     public UpdateWarehouseCommandValidator()
     {
-        RuleFor(p => p.UpdateWarehouseDto)
-            .NotNull().WithMessage("{PropertyName} is required.")
-            .SetValidator(new UpdateWarehouseDtoValidator());
+        RuleFor(p => p.UpdateWarehouseDto).NotNull().WithMessage("{PropertyName} is required.");
+        RuleFor(p => p.UpdateWarehouseDto!).SetValidator(new UpdateWarehouseDtoValidator());
     }
 }


### PR DESCRIPTION
Refactor command validators and update DTO usage

- Updated validation rules in command validators to use the null-forgiving operator (`!`) for DTO properties, enhancing type safety.
- Refactored `DeleteCategoryCommand` and `DeleteCategoryCommandHandler` to use records and added necessary using directives for `FluentResults` and `MediatR`.
- Changed `CreateProductInventoryCommand` and its handler to use `CreateProductInventoryDto` instead of `CreateProductDto`.
- Made similar updates to `UpdateProductInventoryCommand` and its handler, introducing new properties and validation rules.
- Renamed property in `CreateStockMovementCommand` from `StockMovement` to `StockMovementDto` and updated validation logic accordingly.
- Modified `CreateWarehouseCommandValidator` and `UpdateWarehouseCommandValidator` to use the null-forgiving operator on DTO properties.